### PR TITLE
Update off-canvas menu for AI chat functionality

### DIFF
--- a/ai-chat-ui/src/app/shared/menu-offcanvas/menu-offcanvas.component.html
+++ b/ai-chat-ui/src/app/shared/menu-offcanvas/menu-offcanvas.component.html
@@ -6,7 +6,7 @@
   aria-labelledby="offcanvasWithBothOptionsLabel"
 >
   <div class="offcanvas-header">
-    <h5 class="offcanvas-title" id="offcanvasWithBothOptionsLabel">Sessions</h5>
+    <h5 class="offcanvas-title" id="offcanvasWithBothOptionsLabel">AI Chat</h5>
     <button
       type="button"
       class="btn-close"
@@ -15,6 +15,17 @@
     ></button>
   </div>
   <div class="offcanvas-body">
+    <ul class="list-group">
+      <a
+        href="javascript:void(0);"
+        class="list-group-item list-group-item-action"
+        (click)="onClickCreateNewSession()"
+        ><i class="bi bi-chat-text"></i>&nbsp;Create a new chat</a
+      >
+    </ul>
+    <br />
+    <br />
+    <h6 class="offcanvas-title">Sessions</h6>
     <ul class="list-group">
       @for (session of this.storeService.sessions(); track session) {
       <a

--- a/ai-chat-ui/src/app/shared/menu-offcanvas/menu-offcanvas.component.ts
+++ b/ai-chat-ui/src/app/shared/menu-offcanvas/menu-offcanvas.component.ts
@@ -53,6 +53,12 @@ export class MenuOffcanvasComponent {
     });
   }
 
+  /**
+   * Handles the click event for creating a new session.
+   * Clears the current session data using the store service.
+   *
+   * @returns void
+   */
   onClickCreateNewSession(): void {
     this.storeService.clearForNewSession();
   }

--- a/ai-chat-ui/src/app/shared/menu-offcanvas/menu-offcanvas.component.ts
+++ b/ai-chat-ui/src/app/shared/menu-offcanvas/menu-offcanvas.component.ts
@@ -52,4 +52,8 @@ export class MenuOffcanvasComponent {
       this.storeService.disablePromptButton.set(false);
     });
   }
+
+  onClickCreateNewSession(): void {
+    this.storeService.clearForNewSession();
+  }
 }

--- a/ai-chat-ui/src/app/store/store.service.ts
+++ b/ai-chat-ui/src/app/store/store.service.ts
@@ -18,4 +18,13 @@ export class StoreService {
   models = signal<ModelDto[]>([]);
   selectedModelId = signal<string>('');
   sessions = signal<SessionDto[]>([]);
+
+  clearForNewSession(): void {
+    this.sessionId.set('');
+    this.messages.set([]);
+    this.disablePromptButton.set(false);
+    this.isStreaming.set(false);
+    this.stream.set('');
+    this.streamMessage.set(new MessageDto('', false, undefined));
+  }
 }

--- a/ai-chat-ui/src/app/store/store.service.ts
+++ b/ai-chat-ui/src/app/store/store.service.ts
@@ -19,6 +19,20 @@ export class StoreService {
   selectedModelId = signal<string>('');
   sessions = signal<SessionDto[]>([]);
 
+  /**
+   * Resets all store states to their initial values, preparing for a new chat session.
+   * This includes clearing the session ID, message history, prompt button state,
+   * streaming flags and current stream content.
+   *
+   * @remarks
+   * This method performs a complete reset of the store by:
+   * - Clearing the session identifier
+   * - Emptying the messages array
+   * - Enabling the prompt button
+   * - Resetting streaming states
+   * - Clearing stream content
+   * - Initializing a new empty stream message
+   */
   clearForNewSession(): void {
     this.sessionId.set('');
     this.messages.set([]);


### PR DESCRIPTION
Update off-canvas menu for AI chat functionality

- Changed title from "Sessions" to "AI Chat".
- Added a new option to create a new chat session.
- Implemented `onClickCreateNewSession` method in `MenuOffcanvasComponent`.
- Introduced `clearForNewSession` method in `StoreService` to reset session-related properties.