### PR TITLE
Update token handling to support larger counts

### DIFF
--- a/RR.AI-Chat/RR.AI-Chat.Entity/Session.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Entity/Session.cs
@@ -11,11 +11,11 @@ namespace RR.AI_Chat.Entity
 
         public List<Conversation>? Conversations { get; set; } = [];
 
-        public int InputTokens { get; set; }
+        public long InputTokens { get; set; }
 
-        public int OutputTokens { get; set; }
+        public long OutputTokens { get; set; }
 
-        public int TotalTokens => InputTokens + OutputTokens;
+        public long TotalTokens => InputTokens + OutputTokens;
 
         public DateTime DateModified { get; set; } 
     }

--- a/RR.AI-Chat/RR.AI-Chat.Repository/AIChatDbContext.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Repository/AIChatDbContext.cs
@@ -26,7 +26,7 @@ namespace RR.AI_Chat.Repository
             {
                 // EF Core will handle ChatMessage serialization automatically
                 entity.Property(e => e.Conversations)
-                      .HasColumnType("nvarchar(max)") // PostgreSQL (use "json" for SQL Server)
+                      .HasColumnType("nvarchar(max)") 
                       .HasConversion(
                       v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
                       v => JsonSerializer.Deserialize<List<Conversation>>(v, (JsonSerializerOptions?)null) ?? new());

--- a/RR.AI-Chat/RR.AI-Chat.Repository/Migrations/20250805221917_Initial.Designer.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Repository/Migrations/20250805221917_Initial.Designer.cs
@@ -12,7 +12,7 @@ using RR.AI_Chat.Repository;
 namespace RR.AI_Chat.Repository.Migrations
 {
     [DbContext(typeof(AIChatDbContext))]
-    [Migration("20250728214751_Initial")]
+    [Migration("20250805221917_Initial")]
     partial class Initial
     {
         /// <inheritdoc />
@@ -228,15 +228,15 @@ namespace RR.AI_Chat.Repository.Migrations
                     b.Property<DateTime>("DateModified")
                         .HasColumnType("datetime2");
 
-                    b.Property<int>("InputTokens")
-                        .HasColumnType("int");
+                    b.Property<long>("InputTokens")
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Name")
                         .HasMaxLength(100)
                         .HasColumnType("nvarchar(100)");
 
-                    b.Property<int>("OutputTokens")
-                        .HasColumnType("int");
+                    b.Property<long>("OutputTokens")
+                        .HasColumnType("bigint");
 
                     b.HasKey("Id");
 

--- a/RR.AI-Chat/RR.AI-Chat.Repository/Migrations/20250805221917_Initial.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Repository/Migrations/20250805221917_Initial.cs
@@ -42,8 +42,8 @@ namespace RR.AI_Chat.Repository.Migrations
                     Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                     Name = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
                     Conversations = table.Column<string>(type: "nvarchar(max)", nullable: true),
-                    InputTokens = table.Column<int>(type: "int", nullable: false),
-                    OutputTokens = table.Column<int>(type: "int", nullable: false),
+                    InputTokens = table.Column<long>(type: "bigint", nullable: false),
+                    OutputTokens = table.Column<long>(type: "bigint", nullable: false),
                     DateModified = table.Column<DateTime>(type: "datetime2", nullable: false),
                     DateCreated = table.Column<DateTime>(type: "datetime2", nullable: false),
                     DateDeactivated = table.Column<DateTime>(type: "datetime2", nullable: true)

--- a/RR.AI-Chat/RR.AI-Chat.Repository/Migrations/AIChatDbContextModelSnapshot.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Repository/Migrations/AIChatDbContextModelSnapshot.cs
@@ -225,15 +225,15 @@ namespace RR.AI_Chat.Repository.Migrations
                     b.Property<DateTime>("DateModified")
                         .HasColumnType("datetime2");
 
-                    b.Property<int>("InputTokens")
-                        .HasColumnType("int");
+                    b.Property<long>("InputTokens")
+                        .HasColumnType("bigint");
 
                     b.Property<string>("Name")
                         .HasMaxLength(100)
                         .HasColumnType("nvarchar(100)");
 
-                    b.Property<int>("OutputTokens")
-                        .HasColumnType("int");
+                    b.Property<long>("OutputTokens")
+                        .HasColumnType("bigint");
 
                     b.HasKey("Id");
 

--- a/RR.AI-Chat/RR.AI-Chat.Service/ChatService.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Service/ChatService.cs
@@ -93,6 +93,18 @@ namespace RR.AI_Chat.Service
             {
                 cancellationToken.ThrowIfCancellationRequested();
                 sb.Append(message.Text);
+                if (message.Contents != null && 
+                    message.Contents.Count > 0)
+                {
+                    // Check for usage content to track token consumption during streaming
+                    var usageContent = message.Contents.OfType<UsageContent>().FirstOrDefault();
+                    if (usageContent != null)
+                    {
+                        // Update session token tracking if needed
+                        session.InputTokens += usageContent.Details.InputTokenCount ?? 0;
+                        session.OutputTokens += usageContent.Details?.OutputTokenCount ?? 0;
+                    }
+                }
                 yield return message.Text;
             }
 


### PR DESCRIPTION
This pull request updates the way token counts are handled in the chat session model and related database schema to support larger values, and also improves token tracking during streaming in the chat service. The main changes are grouped below:

**Database and Model Updates:**

* Changed the data type of `InputTokens`, `OutputTokens`, and `TotalTokens` from `int` to `long` in the `Session` entity to support larger token counts.
* Updated the Entity Framework migration and model snapshot files to reflect the change from `int` to `bigint` for the `InputTokens` and `OutputTokens` columns in the database schema. [[1]](diffhunk://#diff-37d40c58d64a24d2946c30c3296f76050cc87d85083ab43576cf3ea502cd2224L231-R239) [[2]](diffhunk://#diff-d707059086cad253fae8abb912c9d2265159e9379530363805509e559d20b511L45-R46) [[3]](diffhunk://#diff-b801d2ad3b3885483029fe3db683c366d5daed8ef9b7ef2500de150bd2c3486fL228-R236)
* Renamed the migration files to reflect the new migration timestamp.

**Service Logic Enhancement:**

* Improved the `ChatService` to update session token counts (`InputTokens` and `OutputTokens`) in real time during streaming, by checking for `UsageContent` in streamed messages.Changed InputTokens and OutputTokens in Session.cs from int to long. Updated corresponding migration files to reflect these changes in the database schema. Added logic in ChatService.cs to track token consumption during streaming responses. Created new migration files to ensure the database is aligned with the updated model definitions. These changes enhance the application's ability to handle larger token values and improve tracking of token usage.