### PR TITLE
Enhance message bubble responsiveness on small screens

### DIFF
--- a/ai-chat-ui/src/app/components/home/message-bubble/message-bubble.component.scss
+++ b/ai-chat-ui/src/app/components/home/message-bubble/message-bubble.component.scss
@@ -2,6 +2,15 @@
   max-width: 75%;
   position: relative;
   margin: 4px 0;
+
+  // Use more width on smaller screens
+  @media (max-width: 768px) {
+    max-width: 99%;
+  }
+
+  @media (max-width: 480px) {
+    max-width: 99%;
+  }
 }
 
 .message-content {


### PR DESCRIPTION
Updated CSS for `.message-bubble` to set max-width to 99% for screens up to 768px and 480px, improving layout on smaller devices.