### PR TITLE
Add MCP server service and related functionality

### DIFF
--- a/RR.AI-Chat/RR.AI-Chat.Api/Program.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Api/Program.cs
@@ -104,6 +104,7 @@ builder.Services.AddTransient<IDocumentService, DocumentService>();
 builder.Services.AddTransient<IDocumentToolService, DocumentToolService>();
 builder.Services.AddTransient<ISessionService, SessionService>();
 builder.Services.AddTransient<IModelService, ModelService>();
+builder.Services.AddTransient<IMcpServerService, McpServerService>();
 
 var app = builder.Build();
 

--- a/RR.AI-Chat/RR.AI-Chat.Api/RR.AI-Chat.Api.csproj
+++ b/RR.AI-Chat/RR.AI-Chat.Api/RR.AI-Chat.Api.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.Extensions.AI" Version="9.7.1" />
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.7.1" />
     <PackageReference Include="Microsoft.Extensions.AI.OpenAI" Version="9.7.1-preview.1.25365.4" />
+    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.3" />
     <PackageReference Include="OllamaSharp" Version="5.3.4" />
     <PackageReference Include="OpenAI" Version="2.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />

--- a/RR.AI-Chat/RR.AI-Chat.Entity/McpServer.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Entity/McpServer.cs
@@ -1,0 +1,20 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace RR.AI_Chat.Entity
+{
+    [Table(nameof(McpServer), Schema = "AI")]
+    public class McpServer : BaseEntity
+    {
+        [StringLength(250)]
+        public string Name { get; set; } = null!;
+
+        [StringLength(250)]
+        public string Command { get; set; } = null!;
+
+        public List<string> Arguments { get; set; } = null!;
+
+        [StringLength(2000)]
+        public string? WorkingDirectory { get; set; }
+    }
+}

--- a/RR.AI-Chat/RR.AI-Chat.Repository/AIChatDbContext.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Repository/AIChatDbContext.cs
@@ -17,6 +17,8 @@ namespace RR.AI_Chat.Repository
 
         public virtual DbSet<Model> Models { get; set; }
 
+        public virtual DbSet<McpServer> McpServers { get; set; }
+
         public virtual DbSet<Session> Sessions { get; set; }
         #endregion
 
@@ -35,8 +37,18 @@ namespace RR.AI_Chat.Repository
 
             modelBuilder.Entity<DocumentPage>().Property(p => p.Embedding).HasColumnType("vector(1536)");
 
+            modelBuilder.Entity<McpServer>(e =>
+            {
+                e.Property(p => p.Arguments)
+                    .HasColumnType("nvarchar(max)")
+                    .HasConversion(
+                        v => JsonSerializer.Serialize(v, (JsonSerializerOptions?)null),
+                        v => JsonSerializer.Deserialize<List<string>>(v, (JsonSerializerOptions?)null) ?? new());
+            });
+
             modelBuilder.ApplyConfiguration(new AIServiceConfiguration());
             modelBuilder.ApplyConfiguration(new ModelConfiguration());
+            modelBuilder.ApplyConfiguration(new McpServerConfiguration());
         }
     }
 }

--- a/RR.AI-Chat/RR.AI-Chat.Repository/Configurations/McpServerConfiguration.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Repository/Configurations/McpServerConfiguration.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using RR.AI_Chat.Entity;
+
+namespace RR.AI_Chat.Repository.Configurations
+{
+    public class McpServerConfiguration : IEntityTypeConfiguration<McpServer>
+    {
+        public void Configure(EntityTypeBuilder<McpServer> builder)
+        {
+            var dateTime = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+            builder.HasData(
+                
+                new McpServer
+                {
+                    Id = new("0a515abd-7d7d-48f5-9037-531745843548"),
+                    Name = "Test MCP Server",
+                    Command = "dotnet",
+                    Arguments = ["run", "--project", "C:\\Users\\Rorro\\source\\repos\\RR.MCPServer\\RR.MCPServer\\RR.MCPServer.csproj", "--configuration", "Release"],
+                    WorkingDirectory = "C:\\Users\\Rorro\\source\\repos\\RR.MCPServer\\RR.MCPServer",
+                    DateCreated = dateTime
+                }
+            );
+        }
+    }
+}

--- a/RR.AI-Chat/RR.AI-Chat.Repository/Migrations/20250809163328_Initial.Designer.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Repository/Migrations/20250809163328_Initial.Designer.cs
@@ -12,7 +12,7 @@ using RR.AI_Chat.Repository;
 namespace RR.AI_Chat.Repository.Migrations
 {
     [DbContext(typeof(AIChatDbContext))]
-    [Migration("20250808210222_Initial")]
+    [Migration("20250809163328_Initial")]
     partial class Initial
     {
         /// <inheritdoc />
@@ -134,6 +134,52 @@ namespace RR.AI_Chat.Repository.Migrations
                     b.HasIndex("DocumentId");
 
                     b.ToTable("DocumentPage", "AI");
+                });
+
+            modelBuilder.Entity("RR.AI_Chat.Entity.McpServer", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Arguments")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Command")
+                        .IsRequired()
+                        .HasMaxLength(250)
+                        .HasColumnType("nvarchar(250)");
+
+                    b.Property<DateTime>("DateCreated")
+                        .HasColumnType("datetime2");
+
+                    b.Property<DateTime?>("DateDeactivated")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(250)
+                        .HasColumnType("nvarchar(250)");
+
+                    b.Property<string>("WorkingDirectory")
+                        .HasMaxLength(2000)
+                        .HasColumnType("nvarchar(2000)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("McpServer", "AI");
+
+                    b.HasData(
+                        new
+                        {
+                            Id = new Guid("0a515abd-7d7d-48f5-9037-531745843548"),
+                            Arguments = "[\"run\",\"--project\",\"C:\\\\Users\\\\Rorro\\\\source\\\\repos\\\\RR.MCPServer\\\\RR.MCPServer\\\\RR.MCPServer.csproj\",\"--configuration\",\"Release\"]",
+                            Command = "dotnet",
+                            DateCreated = new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
+                            Name = "Test MCP Server",
+                            WorkingDirectory = "C:\\Users\\Rorro\\source\\repos\\RR.MCPServer\\RR.MCPServer"
+                        });
                 });
 
             modelBuilder.Entity("RR.AI_Chat.Entity.Model", b =>

--- a/RR.AI-Chat/RR.AI-Chat.Repository/Migrations/20250809163328_Initial.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Repository/Migrations/20250809163328_Initial.cs
@@ -35,6 +35,24 @@ namespace RR.AI_Chat.Repository.Migrations
                 });
 
             migrationBuilder.CreateTable(
+                name: "McpServer",
+                schema: "AI",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: false),
+                    Command = table.Column<string>(type: "nvarchar(250)", maxLength: 250, nullable: false),
+                    Arguments = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    WorkingDirectory = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: true),
+                    DateCreated = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    DateDeactivated = table.Column<DateTime>(type: "datetime2", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_McpServer", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
                 name: "Session",
                 schema: "AI",
                 columns: table => new
@@ -139,6 +157,12 @@ namespace RR.AI_Chat.Repository.Migrations
                 });
 
             migrationBuilder.InsertData(
+                schema: "AI",
+                table: "McpServer",
+                columns: new[] { "Id", "Arguments", "Command", "DateCreated", "DateDeactivated", "Name", "WorkingDirectory" },
+                values: new object[] { new Guid("0a515abd-7d7d-48f5-9037-531745843548"), "[\"run\",\"--project\",\"C:\\\\Users\\\\Rorro\\\\source\\\\repos\\\\RR.MCPServer\\\\RR.MCPServer\\\\RR.MCPServer.csproj\",\"--configuration\",\"Release\"]", "dotnet", new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc), null, "Test MCP Server", "C:\\Users\\Rorro\\source\\repos\\RR.MCPServer\\RR.MCPServer" });
+
+            migrationBuilder.InsertData(
                 schema: "AI.Ref",
                 table: "Model",
                 columns: new[] { "Id", "AIServiceId", "DateCreated", "DateDeactivated", "IsToolEnabled", "Name" },
@@ -187,6 +211,10 @@ namespace RR.AI_Chat.Repository.Migrations
         {
             migrationBuilder.DropTable(
                 name: "DocumentPage",
+                schema: "AI");
+
+            migrationBuilder.DropTable(
+                name: "McpServer",
                 schema: "AI");
 
             migrationBuilder.DropTable(

--- a/RR.AI-Chat/RR.AI-Chat.Repository/Migrations/AIChatDbContextModelSnapshot.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Repository/Migrations/AIChatDbContextModelSnapshot.cs
@@ -133,6 +133,52 @@ namespace RR.AI_Chat.Repository.Migrations
                     b.ToTable("DocumentPage", "AI");
                 });
 
+            modelBuilder.Entity("RR.AI_Chat.Entity.McpServer", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uniqueidentifier");
+
+                    b.Property<string>("Arguments")
+                        .IsRequired()
+                        .HasColumnType("nvarchar(max)");
+
+                    b.Property<string>("Command")
+                        .IsRequired()
+                        .HasMaxLength(250)
+                        .HasColumnType("nvarchar(250)");
+
+                    b.Property<DateTime>("DateCreated")
+                        .HasColumnType("datetime2");
+
+                    b.Property<DateTime?>("DateDeactivated")
+                        .HasColumnType("datetime2");
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasMaxLength(250)
+                        .HasColumnType("nvarchar(250)");
+
+                    b.Property<string>("WorkingDirectory")
+                        .HasMaxLength(2000)
+                        .HasColumnType("nvarchar(2000)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("McpServer", "AI");
+
+                    b.HasData(
+                        new
+                        {
+                            Id = new Guid("0a515abd-7d7d-48f5-9037-531745843548"),
+                            Arguments = "[\"run\",\"--project\",\"C:\\\\Users\\\\Rorro\\\\source\\\\repos\\\\RR.MCPServer\\\\RR.MCPServer\\\\RR.MCPServer.csproj\",\"--configuration\",\"Release\"]",
+                            Command = "dotnet",
+                            DateCreated = new DateTime(2025, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc),
+                            Name = "Test MCP Server",
+                            WorkingDirectory = "C:\\Users\\Rorro\\source\\repos\\RR.MCPServer\\RR.MCPServer"
+                        });
+                });
+
             modelBuilder.Entity("RR.AI_Chat.Entity.Model", b =>
                 {
                     b.Property<Guid>("Id")

--- a/RR.AI-Chat/RR.AI-Chat.Service/ChatService.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Service/ChatService.cs
@@ -90,7 +90,7 @@ namespace RR.AI_Chat.Service
 
             var model = await _modelService.GetModelAsync(request.ModelId, request.ServiceId);
             var chatClient = GetChatClient(request.ServiceId);
-            var chatOptions = await CreateChatOptions(sessionId, model);
+            var chatOptions = await CreateChatOptions(sessionId, model).ConfigureAwait(false);
             StringBuilder sb = new();
             long totalInputTokens = 0, totalOutputTokens = 0;
             await foreach (var message in chatClient.GetStreamingResponseAsync(session.Conversations.Select(x => new ChatMessage(x.Role, x.Content)) ?? [], chatOptions, cancellationToken))

--- a/RR.AI-Chat/RR.AI-Chat.Service/McpServerService.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Service/McpServerService.cs
@@ -40,7 +40,7 @@ namespace RR.AI_Chat.Service
             var mcpServers = await _ctx.McpServers.AsNoTracking()
                                 .Where(x => !x.DateDeactivated.HasValue)
                                 .ToListAsync();
-            if (mcpServers == null || mcpServers.Count < 0)
+            if (mcpServers == null || mcpServers.Count == 0)
             {
                 _logger.LogWarning("No MCP servers found in the database.");
                 return [];

--- a/RR.AI-Chat/RR.AI-Chat.Service/McpServerService.cs
+++ b/RR.AI-Chat/RR.AI-Chat.Service/McpServerService.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using ModelContextProtocol.Client;
+using RR.AI_Chat.Repository;
+
+namespace RR.AI_Chat.Service
+{
+    /// <summary>
+    /// Defines the contract for MCP (Model Context Protocol) server operations.
+    /// </summary>
+    public interface IMcpServerService
+    {
+        /// <summary>
+        /// Retrieves all available tools from active MCP servers.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+        /// <returns>A list of MCP client tools from all active servers.</returns>
+        Task<IList<McpClientTool>> GetToolsAsync(CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Service for managing MCP (Model Context Protocol) server operations and tool retrieval.
+    /// </summary>
+    /// <param name="logger">Logger instance for recording service operations and errors.</param>
+    /// <param name="ctx">Database context for accessing MCP server configuration data.</param>
+    public class McpServerService(ILogger<McpServerService> logger, AIChatDbContext ctx) : IMcpServerService
+    {
+        private readonly ILogger<McpServerService> _logger = logger;
+        private readonly AIChatDbContext _ctx = ctx;
+
+        /// <summary>
+        /// Retrieves all available tools from active MCP servers by connecting to each server
+        /// and querying their available tools.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token to cancel the operation.</param>
+        /// <returns>A list of MCP client tools aggregated from all active servers.</returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled via the cancellation token.</exception>
+        public async Task<IList<McpClientTool>> GetToolsAsync(CancellationToken cancellationToken = default)
+        {
+            var mcpServers = await _ctx.McpServers.AsNoTracking()
+                                .Where(x => !x.DateDeactivated.HasValue)
+                                .ToListAsync();
+            if (mcpServers == null || mcpServers.Count < 0)
+            {
+                _logger.LogWarning("No MCP servers found in the database.");
+                return [];
+            }
+
+            List<McpClientTool> tools = [];
+            foreach (var server in mcpServers)
+            {
+                var clientTransport = new StdioClientTransport(new StdioClientTransportOptions
+                {
+                    Name = server.Name,
+                    Command = server.Command,
+                    Arguments = server.Arguments,
+                    WorkingDirectory = server.WorkingDirectory,
+                });
+
+                var mcpClient = await McpClientFactory.CreateAsync(clientTransport, null, null, cancellationToken)
+                                .ConfigureAwait(false);
+                var mcpTools = await mcpClient.ListToolsAsync(null, cancellationToken);
+                tools.AddRange(mcpTools);
+            }
+
+            return tools;
+        }
+    }
+}

--- a/RR.AI-Chat/RR.AI-Chat.Service/RR.AI-Chat.Service.csproj
+++ b/RR.AI-Chat/RR.AI-Chat.Service/RR.AI-Chat.Service.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.AI.Abstractions" Version="9.7.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.8" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.8" />
+    <PackageReference Include="ModelContextProtocol" Version="0.3.0-preview.3" />
     <PackageReference Include="PdfPig" Version="0.1.11" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.3" />
   </ItemGroup>


### PR DESCRIPTION
This pull request introduces support for "McpServer" entities in the AI Chat application, allowing the system to manage and utilize MCP server tools within chat interactions. The changes include updates to the database schema, data seeding, dependency injection, and chat option configuration to integrate MCP server functionality alongside existing document tools.

**Database and Entity Changes:**

* Added the `McpServer` entity to the codebase (`McpServer.cs`) and configured its mapping, including properties for name, command, arguments, and working directory.
* Updated the database context (`AIChatDbContext`) to include a `DbSet<McpServer>` and configured JSON serialization for the `Arguments` property; also added initial seed data for MCP servers via `McpServerConfiguration`. [[1]](diffhunk://#diff-cf710af0dafa1f022851ba502b46d347ed345c6a03b1c9c08ff9f13da78e6defR20-R21) [[2]](diffhunk://#diff-cf710af0dafa1f022851ba502b46d347ed345c6a03b1c9c08ff9f13da78e6defR40-R51) [[3]](diffhunk://#diff-b0f9f7b758e41676c4e06d6f69d90b8ca023a109b8b017d67e83cc7e92cce664R1-R26)
* Modified database migrations to create the `McpServer` table, seed it with a test MCP server, and ensure proper teardown on rollback. [[1]](diffhunk://#diff-173c3337230c7d339190dd69dd1cdbffd80bf378293b0ff000ffa63b5217ef08R37-R54) [[2]](diffhunk://#diff-173c3337230c7d339190dd69dd1cdbffd80bf378293b0ff000ffa63b5217ef08R159-R164) [[3]](diffhunk://#diff-173c3337230c7d339190dd69dd1cdbffd80bf378293b0ff000ffa63b5217ef08R216-R219) [[4]](diffhunk://#diff-20001fed8226947b99b866a9be737064a61f66dac80355a782a726117f97205dR139-R184) [[5]](diffhunk://#diff-b801d2ad3b3885483029fe3db683c366d5daed8ef9b7ef2500de150bd2c3486fR136-R181)

**Dependency Injection and Service Integration:**

* Registered `IMcpServerService` and its implementation in the DI container (`Program.cs`), enabling its use throughout the application.
* Injected `IMcpServerService` into `ChatService` and stored it for later use. [[1]](diffhunk://#diff-8ab34057eff0974f441d39afe7d6930abe2a3dbe34c8b56b03b238fe717badccR31) [[2]](diffhunk://#diff-8ab34057eff0974f441d39afe7d6930abe2a3dbe34c8b56b03b238fe717badccR42)

**Chat Options and Tool Aggregation:**

* Refactored the chat options creation logic to be asynchronous and to aggregate both document tools and MCP server tools when the model allows tool usage. This ensures chat interactions can leverage all available tools. [[1]](diffhunk://#diff-8ab34057eff0974f441d39afe7d6930abe2a3dbe34c8b56b03b238fe717badccL91-R93) [[2]](diffhunk://#diff-8ab34057eff0974f441d39afe7d6930abe2a3dbe34c8b56b03b238fe717badccL282-R318)

**Package Management:**

* Added a reference to the `ModelContextProtocol` NuGet package, which may be required for MCP server integration.This commit introduces the `IMcpServerService` and its implementation, `McpServerService`, to manage operations related to MCP (Model Context Protocol) servers, including tool retrieval. The `McpServer` entity is added to the database context, along with necessary configurations and migrations. The `Program.cs` file is updated to register the new service, and the `AIChatDbContext` now includes a `DbSet<McpServer>`. Additionally, the `ChatService` is modified to utilize the MCP server service for enhanced tool functionality. A new package reference for `ModelContextProtocol` is also included.