### PR TITLE
Update launch and task configurations for API and UI debugging

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,11 @@
 {
   "permissions": {
     "allow": [
-      "Bash(xargs grep -l \"navbar\\\\|menu\\\\|sidebar\\\\|layout\")"
+      "Bash(xargs grep -l \"navbar\\\\|menu\\\\|sidebar\\\\|layout\")",
+      "Read(//c/Program Files/Google/Chrome/Application/**)",
+      "Read(//c/Program Files \\(x86\\)/Google/Chrome/Application/**)",
+      "Read(//c/Program Files \\(x86\\)/Microsoft/Edge/Application/**)",
+      "Read(//c/Program Files/Microsoft/Edge/Application/**)"
     ]
   }
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,35 +1,40 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            // Use IntelliSense to find out which attributes exist for C# debugging
-            // Use hover for the description of the existing attributes
-            // For further information visit https://github.com/dotnet/vscode-csharp/blob/main/debugger-launchjson.md.
-            "name": ".NET Core Launch (web)",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/RR.AI-Chat/RR.AI-Chat.Api/bin/Debug/net9.0/RR.AI-Chat.Api.dll",
-            "args": [],
-            "cwd": "${workspaceFolder}/RR.AI-Chat/RR.AI-Chat.Api",
-            "stopAtEntry": false,
-            // Enable launching a web browser when ASP.NET Core starts. For more information: https://aka.ms/VSCode-CS-LaunchJson-WebBrowser
-            "serverReadyAction": {
-                "action": "openExternally",
-                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
-            },
-            "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-            },
-            "sourceFileMap": {
-                "/Views": "${workspaceFolder}/Views"
-            }
-        },
-        {
-            "name": ".NET Core Attach",
-            "type": "coreclr",
-            "request": "attach"
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "API (Debug)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build-api",
+      "program": "${workspaceFolder}/RR.AI-Chat/RR.AI-Chat.Api/bin/Debug/net10.0/RR.AI-Chat.Api.dll",
+      "args": [],
+      "cwd": "${workspaceFolder}/RR.AI-Chat/RR.AI-Chat.Api",
+      "stopAtEntry": false,
+      "serverReadyAction": {
+        "action": "openExternally",
+        "pattern": "\\bNow listening on:\\s+(https?://\\S+)",
+        "uriFormat": "%s/swagger"
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "ASPNETCORE_URLS": "https://localhost:7045;http://localhost:5247"
+      }
+    },
+    {
+      "name": "UI (Debug)",
+      "type": "msedge",
+      "request": "launch",
+      "preLaunchTask": "serve-ui",
+      "url": "http://localhost:4200/",
+      "webRoot": "${workspaceFolder}/ai-chat-ui",
+      "sourceMaps": true
+    }
+  ],
+  "compounds": [
+    {
+      "name": "API + UI (Debug)",
+      "configurations": ["API (Debug)", "UI (Debug)"],
+      "stopAll": true
+    }
+  ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,41 +1,37 @@
 {
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "build",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "build",
-                "${workspaceFolder}/RR.AI-Chat/RR.AI-Chat.sln",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary;ForceNoAlign"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "publish",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "publish",
-                "${workspaceFolder}/RR.AI-Chat/RR.AI-Chat.sln",
-                "/property:GenerateFullPaths=true",
-                "/consoleloggerparameters:NoSummary;ForceNoAlign"
-            ],
-            "problemMatcher": "$msCompile"
-        },
-        {
-            "label": "watch",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "watch",
-                "run",
-                "--project",
-                "${workspaceFolder}/RR.AI-Chat/RR.AI-Chat.sln"
-            ],
-            "problemMatcher": "$msCompile"
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "build-api",
+      "command": "dotnet",
+      "type": "process",
+      "args": [
+        "build",
+        "${workspaceFolder}/RR.AI-Chat/RR.AI-Chat.Api/RR.AI-Chat.Api.csproj",
+        "/property:GenerateFullPaths=true",
+        "/consoleloggerparameters:NoSummary;ForceNoAlign"
+      ],
+      "problemMatcher": "$msCompile"
+    },
+    {
+      "label": "serve-ui",
+      "type": "npm",
+      "script": "start",
+      "path": "ai-chat-ui",
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "typescript",
+        "pattern": "$tsc",
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": {
+            "regexp": "(.*?)"
+          },
+          "endsPattern": {
+            "regexp": "Local:\\s+http"
+          }
         }
-    ]
+      }
+    }
+  ]
 }


### PR DESCRIPTION
This pull request updates local development settings and task configurations to streamline the debugging process for both the API and UI components of the project. The changes focus on improving launch and task definitions in VS Code, updating permissions for reading browser application files, and refining build and serve tasks for better clarity and usability.

**Development environment improvements:**

* Updated `.vscode/launch.json` to add separate debug configurations for the API (`API (Debug)`) and UI (`UI (Debug)`), including a compound configuration to launch both simultaneously, and enhanced server readiness actions to open the Swagger UI automatically.
* Changed `.vscode/tasks.json` to replace generic build/publish/watch tasks with more targeted tasks: `build-api` for API builds and `serve-ui` for running the UI, including improved background task handling and problem matching for TypeScript.

**Permissions updates:**

* Extended `.claude/settings.local.json` permissions to allow reading Chrome and Edge browser application directories, supporting broader local development and testing scenarios.