### PR TITLE
Implement conversation locking and improve Cosmos DB interactions

### DIFF
--- a/enterprise-gpt-api/Enterprise.Gpt.Api/Controllers/ConversationsController.cs
+++ b/enterprise-gpt-api/Enterprise.Gpt.Api/Controllers/ConversationsController.cs
@@ -57,15 +57,39 @@ namespace Enterprise.Gpt.Api.Controllers
         [HttpPost("{id}/stream")]
         public async Task StreamConversationAsync(Guid id, CreateConversationStreamActionDto request, CancellationToken cancellationToken)
         {
-            Response.Headers.Append("Content-Type", "text/event-stream");
-            Response.Headers.Append("Cache-Control", "no-cache");
-            Response.Headers.Append("Connection", "keep-alive");
+            // Headers are set on the first fragment rather than up front: setting them eagerly left
+            // an error response (a 409 for a conversation that is already streaming, say) carrying
+            // streaming headers alongside its JSON body. Connection is omitted deliberately — it is
+            // a hop-by-hop header Kestrel owns, and it is invalid under HTTP/2.
+            var headersSet = false;
 
             await foreach (var message in _conversationService.StreamConversationAsync(id, request, cancellationToken))
             {
+                if (!headersSet)
+                {
+                    SetStreamingHeaders();
+                    headersSet = true;
+                }
+
                 await Response.WriteAsync($"{message}", cancellationToken);
                 await Response.Body.FlushAsync(cancellationToken);
             }
+
+            // A model that produced nothing still owes the client a well-formed empty stream
+            // rather than a bare 200 the reader cannot interpret.
+            if (!headersSet)
+            {
+                SetStreamingHeaders();
+            }
+        }
+
+        /// <summary>
+        /// Applies the response headers for a server-sent event stream.
+        /// </summary>
+        private void SetStreamingHeaders()
+        {
+            Response.ContentType = "text/event-stream";
+            Response.Headers.CacheControl = "no-cache";
         }
 
         [HttpGet("{id}/messages")]

--- a/enterprise-gpt-api/Enterprise.Gpt.Api/ExceptionHandlers/GlobalExceptionHandler.cs
+++ b/enterprise-gpt-api/Enterprise.Gpt.Api/ExceptionHandlers/GlobalExceptionHandler.cs
@@ -9,6 +9,7 @@ namespace Enterprise.Gpt.Api.ExceptionHandlers
     /// <summary>
     /// Fallback exception handler that maps the remaining exception types
     /// (<see cref="ArgumentException"/>, <see cref="ArgumentNullException"/>,
+    /// <see cref="ConversationBusyException"/>,
     /// <see cref="InvalidOperationException"/>, <see cref="NotFoundException"/>,
     /// <see cref="KeyNotFoundException"/>, <see cref="ForbiddenException"/>,
     /// <see cref="McpAuthorizationRequiredException"/>,
@@ -40,6 +41,15 @@ namespace Enterprise.Gpt.Api.ExceptionHandlers
                 exception.Message,
                 httpContext.TraceIdentifier);
 
+            // Mirrors OperationCanceledExceptionHandler: once the response has started — a chat
+            // stream that faults after its first fragment, say — the status and headers are
+            // immutable and appending a JSON envelope would corrupt the body the client is already
+            // reading. Setting either would itself throw and mask the original exception.
+            if (httpContext.Response.HasStarted)
+            {
+                return true;
+            }
+
             var error = MapToError(httpContext, exception);
 
             httpContext.Response.ContentType = "application/json";
@@ -62,6 +72,16 @@ namespace Enterprise.Gpt.Api.ExceptionHandlers
                 ArgumentException => new ErrorDto
                 {
                     StatusCode = HttpStatusCode.BadRequest,
+                    Errors = [exception.Message],
+                    TraceId = context.TraceIdentifier,
+                    Timestamp = DateTimeOffset.UtcNow
+                },
+                // Ordered before InvalidOperationException only for readability; the type is
+                // unrelated, but contention is a temporary state the caller can retry out of,
+                // so it must not collapse into the 400 bucket alongside validation failures.
+                ConversationBusyException => new ErrorDto
+                {
+                    StatusCode = HttpStatusCode.Conflict,
                     Errors = [exception.Message],
                     TraceId = context.TraceIdentifier,
                     Timestamp = DateTimeOffset.UtcNow

--- a/enterprise-gpt-api/Enterprise.Gpt.Service/AzureCosmosService.cs
+++ b/enterprise-gpt-api/Enterprise.Gpt.Service/AzureCosmosService.cs
@@ -48,7 +48,39 @@ namespace Enterprise.Gpt.Service
         /// <param name="partitionKey">The partition key value of the item.</param>
         /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
         /// <returns>A task that represents the asynchronous operation. The task result contains the updated item.</returns>
+        /// <remarks>
+        /// This replaces the whole document unconditionally, so anything written between the read
+        /// that produced <paramref name="item"/> and this call is silently lost. Prefer
+        /// <see cref="PatchItemAsync"/> whenever only some fields change — it needs no prior read
+        /// and therefore has no lost-update window.
+        /// </remarks>
         Task<T> UpdateItemAsync<T>(T item, string id, string partitionKey, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Applies a set of partial-update operations to an item without reading and rewriting it.
+        /// </summary>
+        /// <param name="id">The unique identifier of the item to patch.</param>
+        /// <param name="partitionKey">The partition key value of the item.</param>
+        /// <param name="operations">The patch operations to apply. Cosmos DB permits at most 10 per call.</param>
+        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation. The task result is <see langword="true"/>
+        /// if the item was patched, or <see langword="false"/> if no item with that identifier exists.
+        /// </returns>
+        /// <remarks>
+        /// Patching is the only way to mutate a document without a read-modify-write window.
+        /// Use it for appends and counters so concurrent writers cannot lose each other's updates.
+        /// </remarks>
+        /// <example>
+        /// <code language="csharp">
+        /// await cosmosService.PatchItemAsync(id, userId,
+        /// [
+        ///     PatchOperation.Add("/messages/-", message),
+        ///     PatchOperation.Increment("/totalTokens", tokens),
+        /// ], cancellationToken);
+        /// </code>
+        /// </example>
+        Task<bool> PatchItemAsync(string id, string partitionKey, IReadOnlyList<PatchOperation> operations, CancellationToken cancellationToken);
 
         /// <summary>
         /// Deletes an item from the Cosmos DB container.
@@ -69,6 +101,11 @@ namespace Enterprise.Gpt.Service
     /// </remarks>
     public class AzureCosmosService : IAzureCosmosService
     {
+        /// <summary>
+        /// The maximum number of operations Cosmos DB accepts in a single patch request.
+        /// </summary>
+        private const int MaxPatchOperations = 10;
+
         private readonly CosmosClient _cosmosClient;
         private readonly Container _container;
 
@@ -138,6 +175,28 @@ namespace Enterprise.Gpt.Service
         {
             var response = await _container.ReplaceItemAsync(item, id, new PartitionKey(partitionKey), cancellationToken: cancellationToken);
             return response;
+        }
+
+        /// <inheritdoc/>
+        /// <exception cref="CosmosException">Thrown when a Cosmos DB error occurs during the patch.</exception>
+        public async Task<bool> PatchItemAsync(string id, string partitionKey, IReadOnlyList<PatchOperation> operations, CancellationToken cancellationToken)
+        {
+            ArgumentOutOfRangeException.ThrowIfGreaterThan(operations.Count, MaxPatchOperations);
+
+            // Suppressing the content response matters more here than on other writes: the patched
+            // resource is a whole conversation transcript, and returning it on every appended
+            // message would undo most of the bandwidth saved by patching instead of replacing.
+            var options = new PatchItemRequestOptions { EnableContentResponseOnWrite = false };
+
+            try
+            {
+                await _container.PatchItemAsync<dynamic>(id, new PartitionKey(partitionKey), operations, options, cancellationToken);
+                return true;
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+            {
+                return false;
+            }
         }
 
         /// <inheritdoc/>

--- a/enterprise-gpt-api/Enterprise.Gpt.Service/ConversationLockService.cs
+++ b/enterprise-gpt-api/Enterprise.Gpt.Service/ConversationLockService.cs
@@ -1,188 +1,179 @@
-﻿using System.Collections.Concurrent;
-
 namespace Enterprise.Gpt.Service
 {
-    public interface IConversationLockService
+    /// <summary>
+    /// Process-local implementation of <see cref="IConversationLockService"/> backed by a
+    /// reference-counted registry of per-conversation semaphores.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Entries are created on first use and removed the instant their last holder releases,
+    /// so the registry stays bounded by the number of <em>concurrently active</em> conversations
+    /// rather than by the number of conversations ever seen. Reference counting is used in place
+    /// of a background eviction sweep because a sweep cannot observe "no one is using this entry"
+    /// atomically with respect to acquisition: an evicted-and-disposed semaphore can be handed to
+    /// a caller that fetched it a moment earlier, after which the next caller creates a fresh
+    /// entry and two turns run against the same conversation — precisely the outcome this
+    /// service exists to prevent.
+    /// </para>
+    /// <para>
+    /// Registered as a singleton; see <see cref="IConversationLockService"/> for the scale-out caveat.
+    /// </para>
+    /// </remarks>
+    public sealed class ConversationLockService : IConversationLockService, IDisposable
     {
         /// <summary>
-        /// Checks whether a conversation is currently locked and busy.
+        /// A single conversation's semaphore together with the number of outstanding
+        /// holders and pending acquirers. <see cref="RefCount"/> is guarded by the owning
+        /// service's gate, never by the semaphore itself.
         /// </summary>
-        /// <param name="conversationId">The unique identifier of the conversation to check.</param>
-        /// <returns><c>true</c> if the conversation is currently locked; otherwise, <c>false</c>.</returns>
-        bool IsConversationBusy(Guid conversationId);
-
-        /// <summary>
-        /// Acquires an exclusive lock for the specified conversation, waiting indefinitely if necessary.
-        /// </summary>
-        /// <param name="conversationId">The unique identifier of the conversation to lock.</param>
-        /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-        /// <returns>A task that represents the asynchronous operation. The task result is an <see cref="IDisposable"/> that releases the lock when disposed.</returns>
-        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled via the <paramref name="cancellationToken"/>.</exception>
-        Task<IDisposable> AcquireLockAsync(Guid conversationId, CancellationToken cancellationToken = default);
-
-        /// <summary>
-        /// Attempts to acquire an exclusive lock for the specified conversation without waiting.
-        /// </summary>
-        /// <param name="conversationId">The unique identifier of the conversation to lock.</param>
-        /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
-        /// <returns>
-        /// A task that represents the asynchronous operation. The task result is an <see cref="IDisposable"/> that releases the lock when disposed, 
-        /// or <c>null</c> if the lock could not be acquired immediately.
-        /// </returns>
-        Task<IDisposable?> TryAcquireLockAsync(Guid conversationId, CancellationToken cancellationToken = default);
-    }
-
-    public class ConversationLockService : IConversationLockService, IDisposable
-    {
-        private class LockInfo
+        private sealed class LockEntry
         {
             /// <summary>
-            /// Gets the semaphore used to control access to the session.
+            /// Gets the binary semaphore that serialises turns for the conversation.
             /// </summary>
-            public SemaphoreSlim Semaphore { get; }
+            public SemaphoreSlim Semaphore { get; } = new(1, 1);
 
             /// <summary>
-            /// Gets or sets the last time this lock was accessed.
+            /// Gets or sets the number of callers currently holding or acquiring this entry.
             /// </summary>
-            public DateTime LastAccessed { get; set; }
-
-            /// <summary>
-            /// Initializes a new instance of the <see cref="LockInfo"/> class.
-            /// </summary>
-            public LockInfo()
-            {
-                Semaphore = new SemaphoreSlim(1, 1);
-                LastAccessed = DateTime.UtcNow;
-            }
+            public int RefCount { get; set; }
         }
 
         /// <summary>
-        /// Releases a conversation lock when disposed.
+        /// Releases a conversation lock and drops the caller's reference to its registry entry.
         /// </summary>
-        private class LockReleaser(ConversationLockService service, Guid conversationId, SemaphoreSlim semaphore) : IDisposable
+        private sealed class LockReleaser(ConversationLockService service, Guid conversationId, LockEntry entry) : IDisposable
         {
-            private bool _disposed;
+            private int _disposed;
 
             /// <summary>
-            /// Releases the semaphore and updates the last accessed time for the conversation.
+            /// Releases the semaphore and returns the entry to the registry. Safe to call more
+            /// than once and from more than one thread; only the first call has any effect.
             /// </summary>
+            /// <remarks>
+            /// The interlocked guard is load-bearing rather than defensive: a concurrent double
+            /// dispose would otherwise call <see cref="SemaphoreSlim.Release()"/> twice, raising
+            /// the count to two and admitting a second concurrent turn.
+            /// </remarks>
             public void Dispose()
             {
-                if (_disposed) return;
-                _disposed = true;
-                semaphore.Release();
-                service.UpdateLastAccessed(conversationId);
+                if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                {
+                    return;
+                }
+
+                entry.Semaphore.Release();
+                service.Return(conversationId, entry);
             }
         }
 
-        private readonly ConcurrentDictionary<Guid, LockInfo> _conversationLocks = new();
-        private readonly Timer _cleanupTimer;
-        private readonly TimeSpan _lockExpirationTime = TimeSpan.FromMinutes(10);
+        private readonly Dictionary<Guid, LockEntry> _locks = [];
+        private readonly Lock _gate = new();
         private bool _disposed;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConversationLockService"/> class.
+        /// Gets the number of conversations currently holding a registry entry. Exposed for tests
+        /// so they can assert that the registry drains rather than leaks.
         /// </summary>
-        /// <remarks>
-        /// Starts a background timer that runs every 5 minutes to clean up stale locks.
-        /// </remarks>
-        public ConversationLockService()
+        internal int ActiveLockCount
         {
-            _cleanupTimer = new Timer(CleanupStaleLocksCallback, null, TimeSpan.FromMinutes(5), TimeSpan.FromMinutes(5));
-        }
-
-        /// <inheritdoc />
-        public bool IsConversationBusy(Guid conversationId)
-        {
-            if (_conversationLocks.TryGetValue(conversationId, out var lockInfo))
+            get
             {
-                return lockInfo.Semaphore.CurrentCount == 0;
-            }
-            return false;
-        }
-
-        /// <inheritdoc />
-        public async Task<IDisposable> AcquireLockAsync(Guid conversationId, CancellationToken cancellationToken = default)
-        {
-            var lockInfo = GetOrCreateLockInfo(conversationId);
-            await lockInfo.Semaphore.WaitAsync(cancellationToken);
-            return new LockReleaser(this, conversationId, lockInfo.Semaphore);
-        }
-
-        /// <inheritdoc />
-        public async Task<IDisposable?> TryAcquireLockAsync(Guid conversationId, CancellationToken cancellationToken = default)
-        {
-            var lockInfo = GetOrCreateLockInfo(conversationId);
-            var acquired = await lockInfo.Semaphore.WaitAsync(0, cancellationToken);
-            return acquired ? new LockReleaser(this, conversationId, lockInfo.Semaphore) : null;
-        }
-
-        /// <summary>
-        /// Gets or creates lock information for the specified conversation.
-        /// </summary>
-        /// <param name="conversationId">The unique identifier of the conversation.</param>
-        /// <returns>The <see cref="LockInfo"/> associated with the conversation.</returns>
-        private LockInfo GetOrCreateLockInfo(Guid conversationId)
-        {
-            var lockInfo = _conversationLocks.GetOrAdd(conversationId, _ => new LockInfo());
-            lockInfo.LastAccessed = DateTime.UtcNow;
-            return lockInfo;
-        }
-
-        /// <summary>
-        /// Updates the last accessed time for the specified conversation.
-        /// </summary>
-        /// <param name="conversationId">The unique identifier of the conversation.</param>
-        private void UpdateLastAccessed(Guid conversationId)
-        {
-            if (_conversationLocks.TryGetValue(conversationId, out var lockInfo))
-            {
-                lockInfo.LastAccessed = DateTime.UtcNow;
-            }
-        }
-
-        /// <summary>
-        /// Callback method that removes stale locks that have not been accessed recently and are not currently held.
-        /// </summary>
-        /// <param name="state">Not used.</param>
-        private void CleanupStaleLocksCallback(object? state)
-        {
-            var now = DateTime.UtcNow;
-            var staleKeys = _conversationLocks
-                .Where(kvp => kvp.Value.Semaphore.CurrentCount > 0 && // Not currently locked
-                             now - kvp.Value.LastAccessed > _lockExpirationTime)
-                .Select(kvp => kvp.Key)
-                .ToList();
-
-            foreach (var key in staleKeys)
-            {
-                if (_conversationLocks.TryRemove(key, out var lockInfo))
+                lock (_gate)
                 {
-                    lockInfo.Semaphore.Dispose();
+                    return _locks.Count;
                 }
             }
         }
 
+        /// <inheritdoc />
+        public async ValueTask<IDisposable?> TryAcquireLockAsync(Guid conversationId, CancellationToken cancellationToken = default)
+        {
+            var entry = Rent(conversationId);
+
+            var acquired = false;
+            try
+            {
+                acquired = await entry.Semaphore.WaitAsync(0, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                // Covers the not-acquired and cancelled paths alike; the successful path hands the
+                // reference on to the releaser, which returns it on disposal.
+                if (!acquired)
+                {
+                    Return(conversationId, entry);
+                }
+            }
+
+            return acquired ? new LockReleaser(this, conversationId, entry) : null;
+        }
+
         /// <summary>
-        /// Releases all resources used by the <see cref="ConversationLockService"/>.
+        /// Takes a reference to the conversation's registry entry, creating it if necessary.
+        /// </summary>
+        /// <param name="conversationId">The unique identifier of the conversation.</param>
+        /// <returns>The entry, with its reference count already incremented on the caller's behalf.</returns>
+        /// <exception cref="ObjectDisposedException">Thrown when the service has already been disposed.</exception>
+        private LockEntry Rent(Guid conversationId)
+        {
+            lock (_gate)
+            {
+                ObjectDisposedException.ThrowIf(_disposed, this);
+
+                if (!_locks.TryGetValue(conversationId, out var entry))
+                {
+                    entry = new LockEntry();
+                    _locks[conversationId] = entry;
+                }
+
+                entry.RefCount++;
+
+                return entry;
+            }
+        }
+
+        /// <summary>
+        /// Drops one reference to the conversation's registry entry, removing and disposing it
+        /// once the last reference is gone.
+        /// </summary>
+        /// <param name="conversationId">The unique identifier of the conversation.</param>
+        /// <param name="entry">The entry the caller holds a reference to.</param>
+        private void Return(Guid conversationId, LockEntry entry)
+        {
+            lock (_gate)
+            {
+                if (--entry.RefCount > 0)
+                {
+                    return;
+                }
+
+                _locks.Remove(conversationId);
+            }
+
+            // Reaching zero under the gate means no other caller holds or can obtain this entry:
+            // a concurrent Rent for the same id would have had to take the gate first, and would
+            // have found the entry still present and incremented it above zero.
+            entry.Semaphore.Dispose();
+        }
+
+        /// <summary>
+        /// Marks the service as disposed and abandons the registry.
         /// </summary>
         /// <remarks>
-        /// Disposes the cleanup timer and all semaphores, then clears the lock dictionary.
+        /// Every entry in the registry has at least one reference by construction, so there is
+        /// nothing here to dispose: entries are left for their own <see cref="LockReleaser"/> to
+        /// release and reclaim. Disposing a held semaphore here would fault the release path of a
+        /// request still unwinding during host shutdown, and a <see cref="SemaphoreSlim"/> with no
+        /// allocated wait handle holds no unmanaged resource worth reclaiming at process exit.
         /// </remarks>
         public void Dispose()
         {
-            if (_disposed) return;
-            _disposed = true;
-
-            _cleanupTimer?.Dispose();
-
-            foreach (var lockInfo in _conversationLocks.Values)
+            lock (_gate)
             {
-                lockInfo.Semaphore.Dispose();
+                _disposed = true;
+                _locks.Clear();
             }
-            _conversationLocks.Clear();
-
-            GC.SuppressFinalize(this);
         }
     }
 }

--- a/enterprise-gpt-api/Enterprise.Gpt.Service/ConversationService.cs
+++ b/enterprise-gpt-api/Enterprise.Gpt.Service/ConversationService.cs
@@ -9,6 +9,7 @@ using Enterprise.Gpt.Dto;
 using Enterprise.Gpt.Dto.Actions.Chat;
 using Enterprise.Gpt.Entity;
 using Enterprise.Gpt.Repository;
+using Microsoft.Azure.Cosmos;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Conversation = Enterprise.Gpt.Entity.Conversation;
@@ -37,8 +38,6 @@ namespace Enterprise.Gpt.Service
         IAsyncEnumerable<string?> StreamConversationAsync(Guid id, CreateConversationStreamActionDto request, CancellationToken cancellationToken);
 
         Task<ChatConversationDto> GetConversationMessagesAsync(Guid id, CancellationToken cancellationToken);
-
-        bool IsConversationBusy(Guid id);
     }
 
     public class ConversationService(ILogger<ConversationService> logger,
@@ -93,7 +92,9 @@ namespace Enterprise.Gpt.Service
 
             var userId = _tokenService.GetOid();
 
-            var transaction = await _ctx.Database.BeginTransactionAsync(cancellationToken);
+            // The Cosmos write is inside the transaction so a failure there rolls the relational row
+            // back rather than leaving a conversation the user can open but never stream.
+            await using var transaction = await _ctx.Database.BeginTransactionAsync(cancellationToken);
             var date = DateTimeOffset.UtcNow;
             var newChat = new Conversation()
             {
@@ -123,9 +124,8 @@ namespace Enterprise.Gpt.Service
                     DateCreated = date,
                 }]
             };
-            await _ctx.SaveChangesAsync(cancellationToken);
 
-            await _cosmosService.CreateItemAsync(newChat, userId.ToString(), cancellationToken);
+            await _cosmosService.CreateItemAsync(newCosmosChat, userId.ToString(), cancellationToken);
 
             await transaction.CommitAsync(cancellationToken);
 
@@ -147,12 +147,13 @@ namespace Enterprise.Gpt.Service
                 return;
             }
 
-            var cosmosConversation = await _cosmosService.GetItemAsync<CosmosConversation>(id.ToString(), userId.ToString(), cancellationToken);
-            if (cosmosConversation != null)
-            {
-                cosmosConversation.DateDeactivated = date;
-                await _cosmosService.UpdateItemAsync(cosmosConversation, cosmosConversation.Id.ToString(), userId.ToString(), cancellationToken);
-            }
+            // Patched rather than read-modify-replaced so a turn streaming concurrently cannot
+            // have its appended messages reverted by this write. Returns false when the document
+            // is absent, which is tolerated for the same reason the previous null check was.
+            await _cosmosService.PatchItemAsync(id.ToString(), userId.ToString(),
+            [
+                PatchOperation.Set("/dateDeactivated", date),
+            ], cancellationToken);
 
             await _ctx.ConversationDocumentChunks
                 .Where(c => c.ConversationDocument.ConversationId == id && !c.DateDeactivated.HasValue)
@@ -194,16 +195,16 @@ namespace Enterprise.Gpt.Service
                 return;
             }
 
-            // Deactivate all chunks for documents in these conversations
-            var conversationIdsInClause = string.Join(", ", conversationIds.Select(id => $"'{id}'"));
-            var cosmosQuery =
-                $"SELECT * FROM c WHERE c.id IN ({conversationIdsInClause}) " +
-                $"AND c.UserId = '{userId}' AND IS_NULL(c.DateDeactivated)";
-            var chats = await _cosmosService.GetItemsAsync<CosmosConversation>(cosmosQuery);
-            foreach (var chat in chats)
+            // Patched by identifier rather than queried and replaced. Besides removing the
+            // read-modify-write window, this drops a cross-partition query whose predicates
+            // (c.UserId, c.DateDeactivated) did not match the documents' camelCase property names
+            // and so never selected anything. SQL has already narrowed the ids to this user's.
+            foreach (var conversationId in conversationIds)
             {
-                chat.DateDeactivated = date;
-                await _cosmosService.UpdateItemAsync(chat, chat.Id.ToString(), userId.ToString(), cancellationToken);
+                await _cosmosService.PatchItemAsync(conversationId.ToString(), userId.ToString(),
+                [
+                    PatchOperation.Set("/dateDeactivated", date),
+                ], cancellationToken);
             }
 
             await _ctx.ConversationDocumentChunks
@@ -268,11 +269,19 @@ namespace Enterprise.Gpt.Service
             }
 
             var name = response.Messages.Last().Text?.Trim() ?? string.Empty;
+            var date = DateTimeOffset.UtcNow;
             conversation.Name = name;
-            conversation.DateModified = DateTimeOffset.UtcNow;
+            conversation.DateModified = date;
             await _ctx.SaveChangesAsync(cancellationToken);
 
-            await _cosmosService.UpdateItemAsync(conversation, conversation.Id.ToString(), conversation.UserId.ToString(), cancellationToken);
+            // Patch the two fields that changed. Passing the SQL entity to a full-document replace
+            // here overwrote the Cosmos document with the relational shape and destroyed the
+            // transcript — and this runs from inside a live stream, on the conversation's first turn.
+            await _cosmosService.PatchItemAsync(conversation.Id.ToString(), conversation.UserId.ToString(),
+            [
+                PatchOperation.Set("/name", name),
+                PatchOperation.Set("/dateModified", date),
+            ], cancellationToken);
         }
 
         public async Task<PaginatedResponseDto<ConversationDto>> SearchConversationsAsync(string? name, int skip = 0, int take = 20, CancellationToken cancellationToken = default)
@@ -331,142 +340,195 @@ namespace Enterprise.Gpt.Service
                     .SetProperty(x => x.DateModified, date),
                     cancellationToken);
 
-            var cosmosConversation = await _cosmosService.GetItemAsync<CosmosConversation>(request.Id.ToString(), userId.ToString(), cancellationToken);
-            if (cosmosConversation != null)
-            {
-                cosmosConversation.Name = request.Name;
-                cosmosConversation.DateModified = date;
-                await _cosmosService.UpdateItemAsync(cosmosConversation, cosmosConversation.Id.ToString(), userId.ToString(), cancellationToken);
-            }
+            await _cosmosService.PatchItemAsync(request.Id.ToString(), userId.ToString(),
+            [
+                PatchOperation.Set("/name", request.Name),
+                PatchOperation.Set("/dateModified", date),
+            ], cancellationToken);
 
             return await GetConversationAsync(request.Id, cancellationToken);
         }
 
         /// <inheritdoc />
-        public bool IsConversationBusy(Guid id) => _conversationLockService.IsConversationBusy(id);
-
-        /// <inheritdoc />
-        public async IAsyncEnumerable<string?> StreamConversationAsync(Guid id, CreateConversationStreamActionDto request, [EnumeratorCancellation] CancellationToken cancellationToken)
+        /// <remarks>
+        /// Deliberately not an iterator method: in an <c>async IAsyncEnumerable</c> the whole body
+        /// is deferred to the first <c>MoveNextAsync</c>, so the argument checks and validation
+        /// would not run until the caller enumerated. Lock acquisition stays inside the iterator
+        /// on purpose — hoisting it here would strand the lock for a caller that took the
+        /// enumerable and never enumerated it — but it still happens before the first fragment is
+        /// produced, which is what lets the controller answer contention with a clean 409.
+        /// </remarks>
+        public IAsyncEnumerable<string?> StreamConversationAsync(Guid id, CreateConversationStreamActionDto request, CancellationToken cancellationToken)
         {
-            ArgumentNullException.ThrowIfNull(request, nameof(request));
+            ArgumentNullException.ThrowIfNull(request);
 
             _createChatStreamActionValidator.ValidateAndThrow(request);
 
-            var lockReleaser = await _conversationLockService.TryAcquireLockAsync(id, cancellationToken);
-            if (lockReleaser == null)
-            {
-                _logger.LogWarning("Conversation {ConversationId} is already being processed.", id);
-                throw new InvalidOperationException($"Conversation {id} is currently being processed. Please wait for the current request to complete.");
-            }
-
             var userId = _tokenService.GetOid();
-            using (lockReleaser)
+
+            return StreamConversationCoreAsync(id, request, userId, cancellationToken);
+        }
+
+        /// <summary>
+        /// Runs a single chat turn under the conversation lock: loads history, streams the model
+        /// response to the caller, then persists the turn.
+        /// </summary>
+        /// <param name="id">The unique identifier of the conversation.</param>
+        /// <param name="request">The validated stream request.</param>
+        /// <param name="userId">The object identifier of the calling user, resolved by the caller.</param>
+        /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+        /// <returns>An asynchronous sequence of response fragments as the model produces them.</returns>
+        /// <exception cref="ConversationBusyException">Thrown when another turn is already in flight for this conversation.</exception>
+        /// <exception cref="NotFoundException">Thrown when the conversation does not exist for this user.</exception>
+        private async IAsyncEnumerable<string?> StreamConversationCoreAsync(Guid id, CreateConversationStreamActionDto request, Guid userId, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            // using var, rather than a separate acquire and using block: it makes acquisition and
+            // release inseparable, so no statement can be introduced between them that could throw
+            // and strand the lock. A stranded conversation lock is unrecoverable short of a restart.
+            using var lockReleaser = await _conversationLockService.TryAcquireLockAsync(id, cancellationToken)
+                ?? throw LogAndCreateBusy(id);
+
+            var conversation = await _ctx.Conversations
+                            .AsNoTracking()
+                            .SingleOrDefaultAsync(x => x.Id == id &&
+                                x.UserId == userId &&
+                                !x.DateDeactivated.HasValue, cancellationToken);
+            if (conversation == null)
             {
-                var conversation = await _ctx.Conversations
-                                .AsNoTracking()
-                                .SingleOrDefaultAsync(x => x.Id == id &&
-                                    x.UserId == userId &&
-                                    !x.DateDeactivated.HasValue, cancellationToken);
-                if (conversation == null)
-                {
-                    _logger.LogError("Conversation with id {Id} not found.", id);
-                    throw new NotFoundException($"Conversation with id {id} not found.");
-                }
-
-                var cosmosConversation = await _cosmosService.GetItemAsync<CosmosConversation>(id.ToString(), userId.ToString(), cancellationToken);
-                if (cosmosConversation == null)
-                {
-                    _logger.LogError("Conversation {Id} not found.", id);
-                    throw new NotFoundException($"Conversation {id} not found.");
-                }
-
-                if (cosmosConversation.Messages.Count == 1)
-                {
-                    await UpdateConversationNameAsync(id, request, cancellationToken);
-                }
-
-                var conversations = new List<ChatMessage>(cosmosConversation.Messages.Select(x => new ChatMessage(MappingService.MapToChatRole(x.Role), x.Content)))
-                {
-                    new(ChatRole.User, request.Prompt)
-                };
-
-                var model = await _modelService.GetModelAsync(request.ModelId, cancellationToken);
-                var chatClient = _azureAIFoundry;
-                var (chatOptions, toolLeases) = await CreateChatOptionsAsync(id, model, request.McpServers, cancellationToken).ConfigureAwait(false);
-                StringBuilder sb = new();
-                long totalInputTokens = 0, totalOutputTokens = 0;
-
-                // The lease set (null when no MCPs are selected) must stay alive for the whole
-                // stream: the attached tools invoke through the leased clients. await using
-                // releases the leases on completion, fault, or client disconnect alike.
-                await using (toolLeases)
-                {
-                    await foreach (var message in chatClient.GetStreamingResponseAsync(conversations, chatOptions, cancellationToken))
-                    {
-                        cancellationToken.ThrowIfCancellationRequested();
-
-                        if (!string.IsNullOrEmpty(message.Text))
-                        {
-                            sb.Append(message.Text);
-                        }
-
-                        if (message.Contents != null &&
-                            message.Contents.Count > 0)
-                        {
-                            // Check for usage content to track token consumption during streaming
-                            var usageContent = message.Contents.OfType<UsageContent>().FirstOrDefault();
-                            if (usageContent != null)
-                            {
-                                totalInputTokens += usageContent.Details?.InputTokenCount ?? 0;
-                                totalOutputTokens += usageContent.Details?.OutputTokenCount ?? 0;
-                            }
-                        }
-                        yield return message.Text;
-                    }
-                }
-
-                var date = DateTimeOffset.UtcNow;
-
-                await _ctx.Conversations
-                    .Where(s => s.Id == id)
-                    .ExecuteUpdateAsync(s => s
-                        .SetProperty(x => x.InputTokens, x => x.InputTokens + totalInputTokens)
-                        .SetProperty(x => x.OutputTokens, x => x.OutputTokens + totalOutputTokens)
-                        .SetProperty(x => x.DateModified, date),
-                        cancellationToken);
-
-                cosmosConversation = await _cosmosService.GetItemAsync<CosmosConversation>(id.ToString(), userId.ToString(), cancellationToken);
-                if (cosmosConversation != null)
-                {
-                    cosmosConversation.DateModified = date;
-                    cosmosConversation.TotalTokens = cosmosConversation.TotalTokens + totalInputTokens + totalOutputTokens;
-                    cosmosConversation.Messages.Add(new()
-                    {
-                        Id = Guid.NewGuid(),
-                        Content = request.Prompt,
-                        DateCreated = date,
-                        Model = model.Name,
-                        Role = ChatRoles.User,
-                        Tokens = 0,
-                    });
-                    cosmosConversation.Messages.Add(new()
-                    {
-                        Id = Guid.NewGuid(),
-                        Content = sb.ToString(),
-                        DateCreated = date,
-                        Model = model.Name,
-                        Role = ChatRoles.Assistant,
-                        Usage = new CosmosConversationUsage
-                        {
-                            InputTokens = totalInputTokens,
-                            OutputTokens = totalOutputTokens
-                        }
-                    });
-                }
-
-
-                await _cosmosService.UpdateItemAsync(cosmosConversation, id.ToString(), userId.ToString(), cancellationToken);
+                _logger.LogError("Conversation with id {Id} not found.", id);
+                throw new NotFoundException($"Conversation with id {id} not found.");
             }
+
+            var cosmosConversation = await _cosmosService.GetItemAsync<CosmosConversation>(id.ToString(), userId.ToString(), cancellationToken);
+            if (cosmosConversation == null)
+            {
+                _logger.LogError("Conversation {Id} not found.", id);
+                throw new NotFoundException($"Conversation {id} not found.");
+            }
+
+            // Only the seeded system prompt so far, i.e. this is the conversation's first turn:
+            // name it from the opening prompt before answering it.
+            if (cosmosConversation.Messages.Count == 1)
+            {
+                await UpdateConversationNameAsync(id, request, cancellationToken);
+            }
+
+            // Conversations created before the transcript was persisted correctly were written
+            // from the relational entity, which has no messages array at all. Every correctly
+            // created conversation carries at least the system prompt, so an empty transcript here
+            // means the property is absent rather than empty — and Cosmos rejects an append whose
+            // parent path does not exist, so such a document has to be seeded instead.
+            var transcriptExists = cosmosConversation.Messages.Count > 0;
+
+            var conversations = new List<ChatMessage>(cosmosConversation.Messages.Select(x => new ChatMessage(MappingService.MapToChatRole(x.Role), x.Content)))
+            {
+                new(ChatRole.User, request.Prompt)
+            };
+
+            var model = await _modelService.GetModelAsync(request.ModelId, cancellationToken);
+            var chatClient = _azureAIFoundry;
+            var (chatOptions, toolLeases) = await CreateChatOptionsAsync(id, model, request.McpServers, cancellationToken).ConfigureAwait(false);
+            StringBuilder sb = new();
+            long totalInputTokens = 0, totalOutputTokens = 0;
+
+            // The lease set (null when no MCPs are selected) must stay alive for the whole
+            // stream: the attached tools invoke through the leased clients. await using
+            // releases the leases on completion, fault, or client disconnect alike.
+            await using (toolLeases)
+            {
+                await foreach (var message in chatClient.GetStreamingResponseAsync(conversations, chatOptions, cancellationToken))
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+
+                    if (!string.IsNullOrEmpty(message.Text))
+                    {
+                        sb.Append(message.Text);
+                    }
+
+                    if (message.Contents != null &&
+                        message.Contents.Count > 0)
+                    {
+                        // Check for usage content to track token consumption during streaming
+                        var usageContent = message.Contents.OfType<UsageContent>().FirstOrDefault();
+                        if (usageContent != null)
+                        {
+                            totalInputTokens += usageContent.Details?.InputTokenCount ?? 0;
+                            totalOutputTokens += usageContent.Details?.OutputTokenCount ?? 0;
+                        }
+                    }
+                    yield return message.Text;
+                }
+            }
+
+            var date = DateTimeOffset.UtcNow;
+
+            await _ctx.Conversations
+                .Where(s => s.Id == id)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(x => x.InputTokens, x => x.InputTokens + totalInputTokens)
+                    .SetProperty(x => x.OutputTokens, x => x.OutputTokens + totalOutputTokens)
+                    .SetProperty(x => x.DateModified, date),
+                    cancellationToken);
+
+            var userMessage = new CosmosConversationMessage
+            {
+                Id = Guid.NewGuid(),
+                Content = request.Prompt,
+                DateCreated = date,
+                Model = model.Name,
+                Role = ChatRoles.User,
+                Tokens = 0,
+            };
+            var assistantMessage = new CosmosConversationMessage
+            {
+                Id = Guid.NewGuid(),
+                Content = sb.ToString(),
+                DateCreated = date,
+                Model = model.Name,
+                Role = ChatRoles.Assistant,
+                Usage = new CosmosConversationUsage
+                {
+                    InputTokens = totalInputTokens,
+                    OutputTokens = totalOutputTokens
+                }
+            };
+
+            // Appended server-side rather than re-read, mutated and replaced. A full-document
+            // replace would silently revert anything written since the read at the top of this
+            // method — a rename or a soft delete landing mid-stream — and would rewrite the entire
+            // transcript on every turn, which grows the request toward the 2 MB item ceiling.
+            // Operations apply in order, so seeding the array first leaves the second append valid.
+            var persisted = await _cosmosService.PatchItemAsync(id.ToString(), userId.ToString(),
+            [
+                transcriptExists
+                    ? PatchOperation.Add("/messages/-", userMessage)
+                    : PatchOperation.Set<List<CosmosConversationMessage>>("/messages", [userMessage]),
+                PatchOperation.Add("/messages/-", assistantMessage),
+                PatchOperation.Increment("/messageCount", 2),
+                PatchOperation.Increment("/totalTokens", totalInputTokens + totalOutputTokens),
+                PatchOperation.Set("/dateModified", date),
+            ], cancellationToken);
+
+            if (!persisted)
+            {
+                // The token counters have already been committed to SQL, so failing silently here
+                // would bill the turn and lose it. Nothing can be returned to the caller at this
+                // point — the answer has been streamed — so this has to be caught in the logs.
+                _logger.LogError("Conversation {Id} document is missing; the completed turn was not persisted.", id);
+            }
+        }
+
+        /// <summary>
+        /// Logs the contention and builds the exception to throw for a conversation that already
+        /// has a turn in flight.
+        /// </summary>
+        /// <param name="id">The unique identifier of the contended conversation.</param>
+        /// <returns>The exception to throw.</returns>
+        private ConversationBusyException LogAndCreateBusy(Guid id)
+        {
+            _logger.LogWarning("Conversation {ConversationId} is already being processed.", id);
+
+            return new ConversationBusyException($"Conversation {id} is currently being processed. Please wait for the current request to complete.");
         }
 
         /// <inheritdoc />

--- a/enterprise-gpt-api/Enterprise.Gpt.Service/Enterprise.Gpt.Service.csproj
+++ b/enterprise-gpt-api/Enterprise.Gpt.Service/Enterprise.Gpt.Service.csproj
@@ -41,6 +41,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- ConversationLockService.ActiveLockCount is exposed to the unit tests so they can assert
+         that the lock registry drains rather than leaks entries. -->
+    <InternalsVisibleTo Include="Enterprise.Gpt.Unit.Test" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="Files\conversation-history.html">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/enterprise-gpt-api/Enterprise.Gpt.Service/Exceptions/ConversationBusyException.cs
+++ b/enterprise-gpt-api/Enterprise.Gpt.Service/Exceptions/ConversationBusyException.cs
@@ -1,0 +1,15 @@
+namespace Enterprise.Gpt.Service.Exceptions
+{
+    /// <summary>
+    /// Thrown when a chat turn is requested for a conversation that already has one in flight.
+    /// Surfaced as HTTP 409 Conflict so callers can distinguish transient contention from a
+    /// malformed request and retry once the current turn completes.
+    /// </summary>
+    public class ConversationBusyException : Exception
+    {
+        public ConversationBusyException(string message) : base(message) { }
+
+        public ConversationBusyException(string message, Exception innerException)
+            : base(message, innerException) { }
+    }
+}

--- a/enterprise-gpt-api/Enterprise.Gpt.Service/IConversationLockService.cs
+++ b/enterprise-gpt-api/Enterprise.Gpt.Service/IConversationLockService.cs
@@ -1,0 +1,42 @@
+namespace Enterprise.Gpt.Service
+{
+    /// <summary>
+    /// Provides exclusive, per-conversation locking so that at most one chat turn runs
+    /// against a given conversation at a time.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The default implementation (<see cref="ConversationLockService"/>) is <b>process-local</b>.
+    /// It guarantees mutual exclusion only within a single API instance; running two or more
+    /// replicas gives each its own registry and therefore no mutual exclusion at all. This
+    /// interface exists as the seam for a distributed lease (for example a Cosmos DB lease
+    /// document with a TTL) should the API ever be scaled out.
+    /// </para>
+    /// <para>
+    /// Acquisition is deliberately non-blocking: a caller that cannot take the lock is expected
+    /// to fail fast rather than queue behind an arbitrarily long model completion.
+    /// </para>
+    /// </remarks>
+    public interface IConversationLockService
+    {
+        /// <summary>
+        /// Attempts to acquire the exclusive lock for the specified conversation without waiting.
+        /// </summary>
+        /// <param name="conversationId">The unique identifier of the conversation to lock.</param>
+        /// <param name="cancellationToken">A token to monitor for cancellation requests.</param>
+        /// <returns>
+        /// A task that represents the asynchronous operation. The task result is an
+        /// <see cref="IDisposable"/> that releases the lock when disposed, or <see langword="null"/>
+        /// if the lock is already held.
+        /// </returns>
+        /// <exception cref="OperationCanceledException">Thrown when the operation is cancelled via <paramref name="cancellationToken"/>.</exception>
+        /// <exception cref="ObjectDisposedException">Thrown when the service has already been disposed.</exception>
+        /// <example>
+        /// <code language="csharp">
+        /// using var releaser = await lockService.TryAcquireLockAsync(conversationId, cancellationToken)
+        ///     ?? throw new ConversationBusyException($"Conversation {conversationId} is currently being processed.");
+        /// </code>
+        /// </example>
+        ValueTask<IDisposable?> TryAcquireLockAsync(Guid conversationId, CancellationToken cancellationToken = default);
+    }
+}

--- a/enterprise-gpt-api/tests/Enterprise.Gpt.Unit.Test/Services/ConversationLockServiceTests.cs
+++ b/enterprise-gpt-api/tests/Enterprise.Gpt.Unit.Test/Services/ConversationLockServiceTests.cs
@@ -1,0 +1,227 @@
+using Enterprise.Gpt.Service;
+using Xunit;
+
+namespace Enterprise.Gpt.Unit.Test.Services;
+
+/// <summary>
+/// Covers <see cref="ConversationLockService"/>: that it grants a conversation to exactly one
+/// caller at a time, that the registry drains as holders release, and that it survives the
+/// concurrent acquire/release churn a chat workload produces.
+/// </summary>
+public sealed class ConversationLockServiceTests
+{
+    [Fact]
+    public async Task TryAcquireLockAsync_WhenNotHeld_ReturnsReleaser()
+    {
+        using var service = new ConversationLockService();
+
+        using var releaser = await service.TryAcquireLockAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(releaser);
+    }
+
+    [Fact]
+    public async Task TryAcquireLockAsync_WhenAlreadyHeld_ReturnsNull()
+    {
+        using var service = new ConversationLockService();
+        var conversationId = Guid.NewGuid();
+
+        using var first = await service.TryAcquireLockAsync(conversationId, TestContext.Current.CancellationToken);
+        var second = await service.TryAcquireLockAsync(conversationId, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(first);
+        Assert.Null(second);
+    }
+
+    [Fact]
+    public async Task TryAcquireLockAsync_AfterRelease_AcquiresAgain()
+    {
+        using var service = new ConversationLockService();
+        var conversationId = Guid.NewGuid();
+
+        var first = await service.TryAcquireLockAsync(conversationId, TestContext.Current.CancellationToken);
+        first!.Dispose();
+        using var second = await service.TryAcquireLockAsync(conversationId, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(second);
+    }
+
+    [Fact]
+    public async Task TryAcquireLockAsync_ForDifferentConversations_BothAcquire()
+    {
+        using var service = new ConversationLockService();
+
+        using var first = await service.TryAcquireLockAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+        using var second = await service.TryAcquireLockAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+    }
+
+    /// <summary>
+    /// Disposal must be idempotent: an unguarded second release either faults on the semaphore
+    /// the first release already reclaimed, or — if another caller re-took the entry in between —
+    /// raises its count to two and admits a second holder alongside the current one.
+    /// </summary>
+    [Fact]
+    public async Task Dispose_CalledTwice_ReleasesSemaphoreOnce()
+    {
+        using var service = new ConversationLockService();
+        var conversationId = Guid.NewGuid();
+
+        var releaser = await service.TryAcquireLockAsync(conversationId, TestContext.Current.CancellationToken);
+        releaser!.Dispose();
+        releaser.Dispose();
+
+        using var next = await service.TryAcquireLockAsync(conversationId, TestContext.Current.CancellationToken);
+        var alongside = await service.TryAcquireLockAsync(conversationId, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(next);
+        Assert.Null(alongside);
+    }
+
+    [Fact]
+    public async Task TryAcquireLockAsync_AfterAllHoldersRelease_RemovesEntry()
+    {
+        using var service = new ConversationLockService();
+        var conversationId = Guid.NewGuid();
+
+        var releaser = await service.TryAcquireLockAsync(conversationId, TestContext.Current.CancellationToken);
+        Assert.Equal(1, service.ActiveLockCount);
+
+        releaser!.Dispose();
+
+        Assert.Equal(0, service.ActiveLockCount);
+    }
+
+    /// <summary>
+    /// A failed acquisition still takes a reference to the registry entry while it probes the
+    /// semaphore; that reference has to be given back or the entry outlives its holder.
+    /// </summary>
+    [Fact]
+    public async Task TryAcquireLockAsync_WhenContended_DoesNotLeakEntryForTheLoser()
+    {
+        using var service = new ConversationLockService();
+        var conversationId = Guid.NewGuid();
+
+        var holder = await service.TryAcquireLockAsync(conversationId, TestContext.Current.CancellationToken);
+        var loser = await service.TryAcquireLockAsync(conversationId, TestContext.Current.CancellationToken);
+        Assert.Null(loser);
+
+        holder!.Dispose();
+
+        Assert.Equal(0, service.ActiveLockCount);
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(64)]
+    public async Task TryAcquireLockAsync_UnderConcurrentContention_OnlyOneSucceeds(int contenders)
+    {
+        using var service = new ConversationLockService();
+        var conversationId = Guid.NewGuid();
+
+        var attempts = await Task.WhenAll(Enumerable.Range(0, contenders).Select(_ =>
+            Task.Run(async () => await service.TryAcquireLockAsync(conversationId, TestContext.Current.CancellationToken))));
+
+        var winners = attempts.Where(releaser => releaser is not null).ToList();
+        Assert.Single(winners);
+
+        foreach (var winner in winners)
+        {
+            winner!.Dispose();
+        }
+
+        Assert.Equal(0, service.ActiveLockCount);
+    }
+
+    /// <summary>
+    /// Regression for the eviction race the reference-counted registry replaced: a sweep that
+    /// removed and disposed entries on a timer could dispose a semaphore a caller had just been
+    /// handed, faulting that caller and letting the next one acquire a fresh entry for a
+    /// conversation that was already in use.
+    /// </summary>
+    [Fact]
+    public async Task TryAcquireLockAsync_UnderRepeatedChurn_DoesNotFaultAndDrains()
+    {
+        using var service = new ConversationLockService();
+        var conversationIds = Enumerable.Range(0, 4).Select(_ => Guid.NewGuid()).ToArray();
+        // Counted per conversation, not in aggregate: distinct conversations are expected to be
+        // held simultaneously, and only same-conversation overlap is a violation.
+        var concurrentHolders = new int[conversationIds.Length];
+
+        await Task.WhenAll(Enumerable.Range(0, 32).Select(worker => Task.Run(async () =>
+        {
+            var index = worker % conversationIds.Length;
+
+            for (var i = 0; i < 200; i++)
+            {
+                var releaser = await service.TryAcquireLockAsync(conversationIds[index], TestContext.Current.CancellationToken);
+                if (releaser is null)
+                {
+                    continue;
+                }
+
+                Assert.Equal(1, Interlocked.Increment(ref concurrentHolders[index]));
+                // Yield while holding, so the window in which an overlap could be observed is
+                // wide enough to actually catch one rather than closing in a few nanoseconds.
+                await Task.Yield();
+                Assert.Equal(0, Interlocked.Decrement(ref concurrentHolders[index]));
+                releaser.Dispose();
+            }
+        })));
+
+        Assert.Equal(0, service.ActiveLockCount);
+    }
+
+    /// <summary>
+    /// A cancelled acquisition never reaches the releaser, so the reference it took while probing
+    /// the semaphore has to be handed back on the exception path too.
+    /// </summary>
+    [Fact]
+    public async Task TryAcquireLockAsync_WhenCancelled_ThrowsAndDoesNotLeakEntry()
+    {
+        using var service = new ConversationLockService();
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await service.TryAcquireLockAsync(Guid.NewGuid(), cts.Token));
+
+        Assert.Equal(0, service.ActiveLockCount);
+    }
+
+    [Fact]
+    public async Task TryAcquireLockAsync_AfterDispose_Throws()
+    {
+        var service = new ConversationLockService();
+        service.Dispose();
+
+        await Assert.ThrowsAsync<ObjectDisposedException>(async () =>
+            await service.TryAcquireLockAsync(Guid.NewGuid(), TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public void Dispose_CalledTwice_DoesNotThrow()
+    {
+        var service = new ConversationLockService();
+
+        service.Dispose();
+        service.Dispose();
+    }
+
+    /// <summary>
+    /// Host shutdown must not fault a turn that is still unwinding, so an entry held by a live
+    /// releaser is left for that releaser to dispose rather than torn down underneath it.
+    /// </summary>
+    [Fact]
+    public async Task Dispose_WithHeldLock_LeavesHolderAbleToRelease()
+    {
+        var service = new ConversationLockService();
+        var releaser = await service.TryAcquireLockAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        service.Dispose();
+
+        releaser!.Dispose();
+    }
+}

--- a/enterprise-gpt-api/tests/Enterprise.Gpt.Unit.Test/Services/ConversationServiceTests.cs
+++ b/enterprise-gpt-api/tests/Enterprise.Gpt.Unit.Test/Services/ConversationServiceTests.cs
@@ -1,7 +1,9 @@
 using FluentValidation;
+using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.AI;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using Enterprise.Gpt.Service.Exceptions;
 using Enterprise.Gpt.Common.Enums;
 using Enterprise.Gpt.Dto;
 using Enterprise.Gpt.Dto.Actions.Chat;
@@ -129,6 +131,200 @@ public sealed class ConversationServiceTests : IDisposable
         return updates;
     }
 
+    /// <summary>
+    /// The Cosmos document must be created from the transcript projection, not the relational
+    /// entity: writing the entity left the conversation with no messages array and no system
+    /// prompt, which the model never saw and the first-turn naming path could never detect.
+    /// </summary>
+    [Fact]
+    public async Task CreateConversationAsync_WhenCalled_PersistsTranscriptWithSystemPrompt()
+    {
+        await _service.CreateConversationAsync(new CreateConversationActionDto(), TestContext.Current.CancellationToken);
+
+        await _cosmosService.Received(1).CreateItemAsync(
+            Arg.Is<CosmosConversation>(cosmos =>
+                cosmos!.Messages.Count == 1
+                && cosmos.Messages[0].Role == ChatRoles.System
+                && cosmos.Messages[0].Content.Length > 0),
+            KnownIds.SeedUserId.ToString(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Renaming used to hand the relational entity to a full-document replace, overwriting the
+    /// transcript with the relational shape — and it runs from inside a live stream.
+    /// </summary>
+    [Fact]
+    public async Task UpdateConversationNameAsync_WhenNamed_PatchesNameWithoutReplacingDocument()
+    {
+        var conversation = await AddConversationAsync();
+        SetUpCosmosConversation(conversation.Id);
+        _chatClient.NamingResponse = "Named Conversation";
+        // The seeded model id, not a substituted one: this path resolves the model name straight
+        // from the database rather than through IModelService.
+        var request = new CreateConversationStreamActionDto
+        {
+            Prompt = "Hello",
+            ModelId = KnownIds.SeedModelId,
+            McpServers = []
+        };
+
+        await _service.UpdateConversationNameAsync(conversation.Id, request, TestContext.Current.CancellationToken);
+
+        await _cosmosService.Received(1).PatchItemAsync(
+            conversation.Id.ToString(),
+            KnownIds.SeedUserId.ToString(),
+            Arg.Is<IReadOnlyList<PatchOperation>>(operations =>
+                operations!.Count == 2
+                && operations[0].OperationType == PatchOperationType.Set && operations[0].Path == "/name"
+                && operations[1].OperationType == PatchOperationType.Set && operations[1].Path == "/dateModified"),
+            Arg.Any<CancellationToken>());
+        await _cosmosService.DidNotReceiveWithAnyArgs().UpdateItemAsync(
+            default(CosmosConversation)!, default!, default!, TestContext.Current.CancellationToken);
+    }
+
+    [Fact]
+    public async Task StreamConversationAsync_WhenConversationLockUnavailable_ThrowsConversationBusyException()
+    {
+        var conversation = await AddConversationAsync();
+        SetUpCosmosConversation(conversation.Id);
+        var model = SetUpModel(isToolEnabled: true);
+        _lockService.TryAcquireLockAsync(conversation.Id, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IDisposable?>((IDisposable?)null));
+        var request = new CreateConversationStreamActionDto
+        {
+            Prompt = "Hello",
+            ModelId = model.Id,
+            McpServers = []
+        };
+
+        await Assert.ThrowsAsync<ConversationBusyException>(
+            () => StreamToEndAsync(conversation.Id, request));
+
+        Assert.Null(_chatClient.CapturedOptions);
+    }
+
+    /// <summary>
+    /// Contention surfaces on the first <c>MoveNextAsync</c> — before any fragment is produced —
+    /// so the controller can still answer with a 409 rather than a half-shaped stream.
+    /// </summary>
+    [Fact]
+    public async Task StreamConversationAsync_WhenConversationLockUnavailable_ThrowsOnFirstMoveNext()
+    {
+        var conversation = await AddConversationAsync();
+        SetUpCosmosConversation(conversation.Id);
+        var model = SetUpModel(isToolEnabled: true);
+        _lockService.TryAcquireLockAsync(conversation.Id, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IDisposable?>((IDisposable?)null));
+        var request = new CreateConversationStreamActionDto
+        {
+            Prompt = "Hello",
+            ModelId = model.Id,
+            McpServers = []
+        };
+
+        var enumerator = _service.StreamConversationAsync(conversation.Id, request, TestContext.Current.CancellationToken)
+            .GetAsyncEnumerator(TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<ConversationBusyException>(async () => await enumerator.MoveNextAsync());
+    }
+
+    [Fact]
+    public async Task StreamConversationAsync_WhenStreamCompletes_ReleasesConversationLock()
+    {
+        var conversation = await AddConversationAsync();
+        SetUpCosmosConversation(conversation.Id);
+        var model = SetUpModel(isToolEnabled: true);
+        var releaser = Substitute.For<IDisposable>();
+        _lockService.TryAcquireLockAsync(conversation.Id, Arg.Any<CancellationToken>())
+            .Returns(new ValueTask<IDisposable?>(releaser));
+        var request = new CreateConversationStreamActionDto
+        {
+            Prompt = "Hello",
+            ModelId = model.Id,
+            McpServers = []
+        };
+
+        await StreamToEndAsync(conversation.Id, request);
+
+        releaser.Received(1).Dispose();
+    }
+
+    /// <summary>
+    /// The turn is appended with a patch rather than a read-modify-replace, so a write that lands
+    /// between loading the history and persisting the answer is not reverted.
+    /// </summary>
+    [Fact]
+    public async Task StreamConversationAsync_WhenStreamCompletes_AppendsMessagesWithoutReplacingDocument()
+    {
+        var conversation = await AddConversationAsync();
+        SetUpCosmosConversation(conversation.Id);
+        var model = SetUpModel(isToolEnabled: true);
+        var request = new CreateConversationStreamActionDto
+        {
+            Prompt = "Hello",
+            ModelId = model.Id,
+            McpServers = []
+        };
+
+        await StreamToEndAsync(conversation.Id, request);
+
+        await _cosmosService.Received(1).PatchItemAsync(
+            conversation.Id.ToString(),
+            KnownIds.SeedUserId.ToString(),
+            Arg.Is<IReadOnlyList<PatchOperation>>(operations =>
+                operations!.Count == 5
+                && operations[0].OperationType == PatchOperationType.Add && operations[0].Path == "/messages/-"
+                && operations[1].OperationType == PatchOperationType.Add && operations[1].Path == "/messages/-"
+                && operations[2].OperationType == PatchOperationType.Increment && operations[2].Path == "/messageCount"
+                && operations[3].OperationType == PatchOperationType.Increment && operations[3].Path == "/totalTokens"
+                && operations[4].OperationType == PatchOperationType.Set && operations[4].Path == "/dateModified"),
+            Arg.Any<CancellationToken>());
+        await _cosmosService.DidNotReceiveWithAnyArgs().UpdateItemAsync(
+            default(CosmosConversation)!, default!, default!, TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>
+    /// Conversations written before the transcript was persisted correctly have no messages array,
+    /// and Cosmos rejects an append whose parent path is absent, so the first turn on such a
+    /// document has to seed the array instead.
+    /// </summary>
+    [Fact]
+    public async Task StreamConversationAsync_WhenTranscriptArrayAbsent_SeedsMessagesInsteadOfAppending()
+    {
+        var conversation = await AddConversationAsync();
+        var date = DateTimeOffset.UtcNow;
+        _cosmosService.GetItemAsync<CosmosConversation>(
+                conversation.Id.ToString(), KnownIds.SeedUserId.ToString(), Arg.Any<CancellationToken>())
+            .Returns(new CosmosConversation
+            {
+                Id = conversation.Id,
+                UserId = KnownIds.SeedUserId,
+                Name = "Legacy Conversation",
+                DateCreated = date,
+                DateModified = date,
+                Messages = []
+            });
+        var model = SetUpModel(isToolEnabled: true);
+        var request = new CreateConversationStreamActionDto
+        {
+            Prompt = "Hello",
+            ModelId = model.Id,
+            McpServers = []
+        };
+
+        await StreamToEndAsync(conversation.Id, request);
+
+        await _cosmosService.Received(1).PatchItemAsync(
+            conversation.Id.ToString(),
+            KnownIds.SeedUserId.ToString(),
+            Arg.Is<IReadOnlyList<PatchOperation>>(operations =>
+                operations!.Count == 5
+                && operations[0].OperationType == PatchOperationType.Set && operations[0].Path == "/messages"
+                && operations[1].OperationType == PatchOperationType.Add && operations[1].Path == "/messages/-"),
+            Arg.Any<CancellationToken>());
+    }
+
     [Fact]
     public async Task StreamConversationAsync_McpServersSelectedWithNonToolModel_ThrowsValidationExceptionWithoutAcquiringTools()
     {
@@ -224,10 +420,21 @@ public sealed class ConversationServiceTests : IDisposable
     {
         public ChatOptions? CapturedOptions { get; private set; }
 
+        /// <summary>
+        /// Gets or sets the name the conversation-naming path should return. Left <see langword="null"/>,
+        /// that path throws, so tests that do not expect naming to run still fail loudly.
+        /// </summary>
+        public string? NamingResponse { get; set; }
+
         public Task<ChatResponse> GetResponseAsync(
             IEnumerable<ChatMessage> messages, ChatOptions? options = null, CancellationToken cancellationToken = default)
         {
-            throw new NotSupportedException("The naming path should not run in these tests.");
+            if (NamingResponse is null)
+            {
+                throw new NotSupportedException("The naming path should not run in these tests.");
+            }
+
+            return Task.FromResult(new ChatResponse(new ChatMessage(ChatRole.Assistant, NamingResponse)));
         }
 
         public async IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(


### PR DESCRIPTION
This pull request introduces several important changes to the conversation streaming and locking infrastructure, error handling, and Cosmos DB operations. The main improvements are: a more robust and efficient conversation lock service, enhanced error handling for conversation contention, and the addition of partial document updates in Cosmos DB. These changes improve concurrency safety, error reporting, and performance.

**Concurrency and Locking Improvements:**

* [`ConversationLockService`](diffhunk://#diff-4dc7af3eaa91ab1cd6fe24f50f23b01eeabe118c84d2ffe7497c8c8934feb434L1-L185): Rewritten as a sealed, reference-counted registry of per-conversation semaphores, removing the background cleanup timer and optimizing for concurrent access and memory usage. The interface is simplified to only expose `TryAcquireLockAsync`, and the lock lifecycle is now reference-counted for precise cleanup.
* [`ConversationService`](diffhunk://#diff-97c68fdf3c2d305994ebd312d75476edf87009e392a02bdd8385cb289eaa56ddL40-L41): Removes the now-unnecessary `IsConversationBusy` method, reflecting the new locking approach.

**Error Handling Enhancements:**

* [`GlobalExceptionHandler.cs`](diffhunk://#diff-d2d5c5ab75cbba83d79d7e91198ad9e20229cc5a317e4f3e0068d2f10eca3fe3R12): Adds handling for `ConversationBusyException`, mapping it to a 409 Conflict response, and ensures no JSON error envelope is appended if the response has already started (e.g., during streaming). [[1]](diffhunk://#diff-d2d5c5ab75cbba83d79d7e91198ad9e20229cc5a317e4f3e0068d2f10eca3fe3R12) [[2]](diffhunk://#diff-d2d5c5ab75cbba83d79d7e91198ad9e20229cc5a317e4f3e0068d2f10eca3fe3R44-R52) [[3]](diffhunk://#diff-d2d5c5ab75cbba83d79d7e91198ad9e20229cc5a317e4f3e0068d2f10eca3fe3R79-R88)

**Cosmos DB Partial Update Support:**

* [`AzureCosmosService`](diffhunk://#diff-005822c6dae4adc31b97256f17edcc2f3ab9415729d236eb3e52536420f1ed6aR51-R84): Adds a `PatchItemAsync` method to allow partial updates (patches) to Cosmos DB documents, reducing the risk of lost updates and improving performance for concurrent writers. Includes detailed XML documentation and an example. [[1]](diffhunk://#diff-005822c6dae4adc31b97256f17edcc2f3ab9415729d236eb3e52536420f1ed6aR51-R84) [[2]](diffhunk://#diff-005822c6dae4adc31b97256f17edcc2f3ab9415729d236eb3e52536420f1ed6aR180-R201)
* [`AzureCosmosService`](diffhunk://#diff-005822c6dae4adc31b97256f17edcc2f3ab9415729d236eb3e52536420f1ed6aR51-R84): Documents the risks of unconditional replacements in `UpdateItemAsync` and recommends patching for partial updates.
* [`AzureCosmosService`](diffhunk://#diff-005822c6dae4adc31b97256f17edcc2f3ab9415729d236eb3e52536420f1ed6aR104-R108): Defines a constant for the maximum number of patch operations per request.

**Streaming Response Handling:**

* [`ConversationsController.cs`](diffhunk://#diff-b3a2f94d88378f8d78ed2ccde0759e07455a9e2622fd8668571bd965a551290fL60-R92): Adjusts when streaming headers are set to avoid sending event-stream headers with error responses, and ensures an empty stream is always well-formed.

**Other:**

* Adds missing `using Microsoft.Azure.Cosmos;` in `ConversationService.cs` to support new Cosmos DB features.…ctions

- Introduced IConversationLockService for managing exclusive locks on conversations to prevent concurrent processing.
- Added ConversationBusyException to handle cases where a conversation is already being processed.
- Refactored ConversationService to utilize patch operations for Cosmos DB updates, ensuring efficient message appending without overwriting existing data.
- Enhanced unit tests for ConversationService and ConversationLockService to cover new locking behavior and ensure correct interaction with Cosmos DB.
- Updated project references and added internals visibility for unit testing.